### PR TITLE
Fix deparseExpr for Var and OpExpr

### DIFF
--- a/oracle_utils.c
+++ b/oracle_utils.c
@@ -2018,7 +2018,7 @@ oracleFetchNext(oracleSession *session)
 
 	if (result != OCI_SUCCESS && result != OCI_NO_DATA)
 	{
-		oracleError_d(FDW_UNABLE_TO_CREATE_EXECUTION,
+		oracleError_d(err_code == 8177 ? FDW_SERIALIZATION_FAILURE : FDW_UNABLE_TO_CREATE_EXECUTION,
 			"error fetching result: OCIStmtFetch2 failed to fetch next result row",
 			oraMessage);
 	}


### PR DESCRIPTION
The code mistakenly assumed that in a join relation, the left side
is always from outerrel and the right side from innerel.

Fix by making no such assumption, and teach deparseExpr to search all
foreign relations whether they belong to a Var or not.

This should fix the problem noticed in https://github.com/yamatattsu/oracle_fdw/commit/77654df8c115a13279189249f25530f705174c33#commitcomment-22432807

(the change in `oracle_utils.c` is something I made to my master branch, it is irrelevant here.)